### PR TITLE
Get rid of Interface suffix in Shared/Application namespace

### DIFF
--- a/src/Shared/Application/Command.php
+++ b/src/Shared/Application/Command.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+interface Command
+{
+}

--- a/src/Shared/Application/Command/CommandInterface.php
+++ b/src/Shared/Application/Command/CommandInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace App\Shared\Application\Command;
-
-interface CommandInterface
-{
-}

--- a/src/Shared/Application/Query.php
+++ b/src/Shared/Application/Query.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+interface Query
+{
+}

--- a/src/Shared/Application/Query/QueryInterface.php
+++ b/src/Shared/Application/Query/QueryInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace App\Shared\Application\Query;
-
-interface QueryInterface
-{
-}

--- a/src/Shared/Domain/Event/EventRepository.php
+++ b/src/Shared/Domain/Event/EventRepository.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Domain\Event;
 
-interface EventRepositoryInterface
+interface EventRepository
 {
     public function getAllEventsFrom(string $destination): array;
     public function save(Event $event): void;

--- a/src/Shared/Infrastructure/Repository/EventStore.php
+++ b/src/Shared/Infrastructure/Repository/EventStore.php
@@ -7,10 +7,10 @@ namespace App\Shared\Infrastructure\Repository;
 use App\Entity\MarsResearchStationEntity;
 use App\Entity\SpaceResearchStationEntity;
 use App\Shared\Domain\Event\Event;
-use App\Shared\Domain\Event\EventRepositoryInterface;
+use App\Shared\Domain\Event\EventRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
-class EventStore implements EventRepositoryInterface
+class EventStore implements EventRepository
 {
     private EntityManagerInterface $entityManager;
 

--- a/src/UI/Rest/Controller/CommandController.php
+++ b/src/UI/Rest/Controller/CommandController.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\UI\Rest\Controller;
 
-use App\Shared\Application\Command\CommandInterface;
+use App\Shared\Application\Command;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -18,11 +18,12 @@ abstract class CommandController extends AbstractController
         $this->bus = $bus;
     }
 
-    protected function handle(CommandInterface $command): void
+    protected function handle(Command $command): void
     {
         $this->bus->dispatch($command);
     }
-    protected function handleWithDelay(CommandInterface $command): void
+
+    protected function handleWithDelay(Command $command): void
     {
         $this->bus->dispatch(new Envelope($command), [
             new DelayStamp(840000),

--- a/src/UI/Rest/Controller/QueryController.php
+++ b/src/UI/Rest/Controller/QueryController.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\UI\Rest\Controller;
 
-use App\Shared\Application\Query\QueryInterface;
+use App\Shared\Application\Query;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -19,7 +19,7 @@ abstract class QueryController extends AbstractController
         $this->queryBus = $queryBus;
     }
 
-    protected function ask(QueryInterface $query): Envelope
+    protected function ask(Query $query): Envelope
     {
         $envelope = $this->queryBus->dispatch($query);
         /** @var HandledStamp $handled */
@@ -28,7 +28,7 @@ abstract class QueryController extends AbstractController
         return $handled->getResult();
     }
 
-    protected function askWithDelay(QueryInterface $query): Envelope
+    protected function askWithDelay(Query $query): Envelope
     {
         $envelope = $this->queryBus->dispatch(new Envelope($query), [
             new DelayStamp(840000),


### PR DESCRIPTION
interface don't need interface suffix because the language itself have interface keyword. If interface suffix will be added that to every class we should add suffix Class which is clearly stupid.

This rule is also described in https://landingi.atlassian.net/wiki/spaces/TEC/pages/56328447/Code+Style